### PR TITLE
Add Args types for rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 import "reflect-metadata";
-import { ResolverData } from "type-graphql";
+import { ArgsDictionary, ResolverData } from "type-graphql";
 
-export type Rule<TContextType = {}> = (
-  D: ResolverData<TContextType>
+export interface ResolverDataWithArgs<
+  TArgsType extends ArgsDictionary,
+  TContextType = {}
+> extends ResolverData<TContextType> {
+  args: TArgsType;
+  context: TContextType;
+}
+
+export type Rule<TContextType = {}, TArgsType extends ArgsDictionary = {}> = (
+  D: ResolverDataWithArgs<TArgsType, TContextType>
 ) => boolean | Promise<boolean>;
 
 export type Rules<TContextType = {}> =

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata";
 
-import { authResolver, Rules } from "../src";
+import { authResolver } from "../src";
 
 const ruleIsTrue = (): boolean => {
   console.log("sync ruleIsTrue");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,11 +2976,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-reflect-metadata@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
-
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz#54d09c7115e1f53dc2314a974b32c1c344efe326"


### PR DESCRIPTION
It is now possible to define the types for `args` in the rule resolver.

```js
const isPostAccessible: Rule<Context, {userId: number}> = ({root, args, context}) => {
  // args.userId of type number will be here
} 
```
