### PR TITLE
ES5 -> ES2015, bumped graphql@^16 and type-graphql@^2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 node_modules/
 
 # Generated folders
-lib/
 coverage/

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+import { ArgsDictionary, ResolverData } from "type-graphql";
+export interface ResolverDataWithArgs<TArgsType extends ArgsDictionary, TContextType = {}> extends ResolverData<TContextType> {
+    args: TArgsType;
+    context: TContextType;
+}
+export declare type Rule<TContextType = {}, TArgsType extends ArgsDictionary = {}> = (D: ResolverDataWithArgs<TArgsType, TContextType>) => boolean | Promise<boolean>;
+export declare type Rules<TContextType = {}> = Rule<TContextType> | RuleObject<TContextType> | Rules<TContextType>[];
+export interface RuleObject<TContextType = {}> {
+    OR?: Rules<TContextType>[];
+    AND?: Rules<TContextType>[];
+    NOT?: Rules<TContextType>[];
+}
+export declare type AuthCheckerFn<TContextType = {}, TRoleType = Rules<TContextType>> = (resolverData: ResolverData<TContextType>, roles: TRoleType) => boolean | Promise<boolean>;
+export declare type FAuthChecker<TContextType = {}, TRoleType = Rules<TContextType>> = AuthCheckerFn<TContextType, TRoleType>;
+export declare const authResolver: FAuthChecker;
+declare const authChecker: FAuthChecker;
+export default authChecker;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,76 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.authResolver = void 0;
+require("reflect-metadata");
+function isRule(rules) {
+    if (typeof rules === "function") {
+        return true;
+    }
+    return false;
+}
+function isRulesArray(rules) {
+    if (Array.isArray(rules)) {
+        const isArrayOfRules = rules.reduce((isRuleAcc, rule) => {
+            if (isRule(rule) || isRulesObject(rule)) {
+                return isRuleAcc && true;
+            }
+            return false;
+        }, true);
+        return isArrayOfRules;
+    }
+    return false;
+}
+function isRulesObject(rules) {
+    if ("OR" in rules || "AND" in rules || "NOT" in rules) {
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+const authResolver = ({ root, args, context, info }, rules) => __awaiter(void 0, void 0, void 0, function* () {
+    if (isRule(rules)) {
+        return yield rules({ root, args, context, info });
+    }
+    else if (isRulesArray(rules)) {
+        return yield rules.reduce((acc, rule) => __awaiter(void 0, void 0, void 0, function* () {
+            return (yield exports.authResolver({ root, args, context, info }, rule)) && acc;
+        }), Promise.resolve(true));
+    }
+    else if (isRulesObject(rules)) {
+        const andRules = rules.AND
+            ? yield rules.AND.reduce((andAcc, rule) => __awaiter(void 0, void 0, void 0, function* () {
+                return ((yield exports.authResolver({ root, args, context, info }, rule)) &&
+                    andAcc);
+            }), Promise.resolve(true))
+            : true;
+        const notRules = rules.NOT
+            ? yield rules.NOT.reduce((notAcc, rule) => __awaiter(void 0, void 0, void 0, function* () {
+                return (!(yield exports.authResolver({ root, args, context, info }, rule)) &&
+                    notAcc);
+            }), Promise.resolve(true))
+            : true;
+        const orRules = rules.OR
+            ? yield rules.OR.reduce((andAcc, rule) => __awaiter(void 0, void 0, void 0, function* () {
+                return ((yield exports.authResolver({ root, args, context, info }, rule)) ||
+                    andAcc);
+            }), Promise.resolve(false))
+            : true;
+        return andRules && orRules && notRules;
+    }
+    return true;
+});
+exports.authResolver = authResolver;
+const authChecker = ({ root, args, context, info }, rules) => __awaiter(void 0, void 0, void 0, function* () {
+    return yield exports.authResolver({ root, args, context, info }, rules);
+});
+exports.default = authChecker;

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "@types/jest": "^27.0.3",
     "@types/node": "^16.6.2",
     "class-validator": "^0.13.1",
-    "graphql": "^15.5.1",
+    "graphql": "^16.7.1",
     "jest": "^27.4.4",
     "ts-node-dev": "^1.1.8",
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "type-graphql": "^1.1.1"
+    "type-graphql": "^2.0.0-beta.2"
   },
   "scripts": {
     "build": "tsc",
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "class-validator": "^0.13.1",
-    "graphql": "^15.5.1",
+    "graphql": "^16.7.1",
     "reflect-metadata": "^0.1.13"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,14 +1157,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/glob@^7.1.3":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
-  integrity sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
-  dependencies:
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1199,30 +1191,25 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/minimatch@*":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
-  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
-
 "@types/node@*", "@types/node@^16.6.2":
   version "16.6.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.6.2.tgz#331b7b9f8621c638284787c5559423822fdffc50"
   integrity sha512-LSw8TZt12ZudbpHc6EkIyDM3nHVWKYrAvGy6EAJfNfjusbwnThqjqxUKKRwuV3iWYeW/LYMzNgaq3MaLffQ2xA==
 
-"@types/node@^14.11.2":
-  version "14.17.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.10.tgz#93f4b095af275a0427114579c10ec7aa696729d7"
-  integrity sha512-09x2d6kNBwjHgyh3jOUE2GE4DFoxDriDvWdu6mFhMP1ysynGYazt4ecZmJlL6/fe4Zi2vtYvTvtL7epjQQrBhA==
+"@types/node@^20.1.2":
+  version "20.3.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.2.tgz#fa6a90f2600e052a03c18b8cb3fd83dd4e599898"
+  integrity sha512-vOBLVQeCQfIcF/2Y7eKFTqrMnizK5lRNQ7ykML/5RuwVXVWxYkgwS7xbt4B6fKCUPgbSL5FSsjHQpaGQP/dQmw==
 
 "@types/prettier@^2.1.5":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
   integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
-"@types/semver@^7.3.3":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
-  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+"@types/semver@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1947,18 +1934,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.6:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
-  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -1969,24 +1944,24 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-graphql-query-complexity@^0.7.0:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/graphql-query-complexity/-/graphql-query-complexity-0.7.2.tgz#7fc6bb20930ab1b666ecf3bbfb24b65b6f08ecc4"
-  integrity sha512-+VgmrfxGEjHI3zuojWOR8bsz7Ycz/BZjNjxnlUieTz5DsB92WoIrYCSZdWG7UWZ3rfcA1Gb2Nf+wB80GsaZWuQ==
+graphql-query-complexity@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/graphql-query-complexity/-/graphql-query-complexity-0.12.0.tgz#5f636ccc54da82225f31e898e7f27192fe074b4c"
+  integrity sha512-fWEyuSL6g/+nSiIRgIipfI6UXTI7bAxrpPlCY1c0+V3pAEUo1ybaKmSBgNr1ed2r+agm1plJww8Loig9y6s2dw==
   dependencies:
     lodash.get "^4.4.2"
 
-graphql-subscriptions@^1.1.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz#2142b2d729661ddf967b7388f7cf1dd4cf2e061d"
-  integrity sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==
+graphql-subscriptions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-2.0.0.tgz#11ec181d475852d8aec879183e8e1eb94f2eb79a"
+  integrity sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==
   dependencies:
     iterall "^1.3.0"
 
-graphql@^15.5.1:
-  version "15.5.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.1.tgz#f2f84415d8985e7b84731e7f3536f8bb9d383aad"
-  integrity sha512-FeTRX67T3LoE3LWAxxOlW2K3Bz+rMYAC18rRguK4wgXaTZMiJwSUwDmPFo3UadAKbzirKIg5Qy+sNJXbpPRnQw==
+graphql@^16.7.1:
+  version "16.7.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.7.1.tgz#11475b74a7bff2aefd4691df52a0eca0abd9b642"
+  integrity sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -3102,6 +3077,13 @@ semver@^7.3.2:
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.0:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -3340,10 +3322,10 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^2.0.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+tslib@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -3362,19 +3344,17 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-type-graphql@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/type-graphql/-/type-graphql-1.1.1.tgz#dc0710d961713b92d3fee927981fa43bf71667a4"
-  integrity sha512-iOOWVn0ehCYMukmnXStbkRwFE9dcjt7/oDcBS1JyQZo9CbhlIll4lHHps54HMEk4A4c8bUPd+DjK8w1/ZrxB4A==
+type-graphql@^2.0.0-beta.2:
+  version "2.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/type-graphql/-/type-graphql-2.0.0-beta.2.tgz#498e8dee56b8ea1f5c3a5ed99aab8105dcb8f050"
+  integrity sha512-MCGxRvNADu5Wp9QEudI/WQgiqHJfjanGcKRk/ErCow6IaG04NNI7o3bjjxQVWC+qDundSOhmaquNdjDiiTbcqQ==
   dependencies:
-    "@types/glob" "^7.1.3"
-    "@types/node" "^14.11.2"
-    "@types/semver" "^7.3.3"
-    glob "^7.1.6"
-    graphql-query-complexity "^0.7.0"
-    graphql-subscriptions "^1.1.0"
-    semver "^7.3.2"
-    tslib "^2.0.1"
+    "@types/node" "^20.1.2"
+    "@types/semver" "^7.5.0"
+    graphql-query-complexity "^0.12.0"
+    graphql-subscriptions "^2.0.0"
+    semver "^7.5.0"
+    tslib "^2.5.0"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
This PR makes this package compatible with the pre-release `type-graphql@2.0.0-beta.2` which provides compatibility with `graphql@^16` and, most importantly `apollo/server@^4` (via transitive dependency on `graphql@^16`). 

This took me ~6 hours to debug, and a lengthy conversation with ChatGPT -- but the TLDR is that due to [this](https://github.com/MichalLytek/type-graphql/blob/4f6085d358499597d5962185ca95cc61dbf06d04/src/helpers/auth-middleware.ts#L14-L19) change in type-graphql, enabling support for class-based authCheckers, this library began to throw a _weird_ error pretty deep in the middleware call stack: 

```
TypeError: Cannot read properties of undefined (reading 'root')
```

After debugging, I discovered that the authChecker, despite being defined as an Arrow Function, had an `authChecker.prototype` value and was passing the above mentioned check erroneously. 

This was due to the `tsconfig.json`, which is targeting `ES5`. Here's ChatGPT's commentary: 

> The target option in your TypeScript configuration is set to "es5", which means TypeScript will transpile your code to ECMAScript 5 syntax. In ES5, arrow functions do not exist and are converted to regular function expressions. This is likely the reason why your arrow functions have a prototype property and why they pass the authChecker.prototype check in AuthMiddleware.

This PR bumps the dependent versions of `type-graphql` and the peer dependency of `graphql`, additionally changing the target from `ES5` to `ES2015` which in my local testing compiles properly to an ES2015 arrow function and allows my auth rules to be evaluated properly. 

```
const authChecker = ({ root, args, context, info }, rules) => __awaiter(void 0, void 0, void 0, function* () {
    return yield exports.authResolver({ root, args, context, info }, rules);
});
exports.default = authChecker;
```

This release should be marked as `0.2.0-beta.2` and be released as `0.2.0` whenever `type-graphql` is ever dropped. 

You can keep an eye on this issue in the type-graphql repo for details on that release: https://github.com/MichalLytek/type-graphql/issues/1418

This PR closes #9 

Pray for me -- my soul is haunted by the ghost of transpilations past. All hail GPT. 